### PR TITLE
Check only the status of "other" pods while determining whether the c…

### DIFF
--- a/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -342,7 +342,7 @@ etcd_configure_rbac() {
 is_new_etcd_cluster() {
     local -a extra_flags
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
-    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
+    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints true)")
     ! debug_execute etcdctl endpoint status --cluster "${extra_flags[@]}"
 }
 


### PR DESCRIPTION
…luster is new.

Proposed Fix:
Modify etcdctl_get_endpoints to exclude the pod's own endpoint before executing etcdctl endpoint status --cluster. This will prevent failures when checking the cluster status during a rolling upgrade.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
